### PR TITLE
chore: update claude-code package to version 1.0.33

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
         npm cache clean --force 2>/dev/null || true
         
         # forceオプション付きでインストール
-        npm install -g @anthropic-ai/claude-code@1.0.2 --force
+        npm install -g @anthropic-ai/claude-code@1.0.33 --force
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
現在以下のようなエラーにより、GitHub Actionsが通らなくなってしまっているため、利用するClaude Codeのバージョンを最新版の1.0.33に変更しました。

```
It looks like your version of Claude Code (1.0.2) needs an update.
A newer version (1.0.24 or higher) is required to continue.
```